### PR TITLE
Set property enumerable and configurable

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,7 +103,9 @@
         }
 
         return key;
-      }
+      },
+      enumerable: true,
+      configurable: true 
     };
     Object.defineProperty(KeyboardEvent.prototype, 'key', proto);
     return proto;


### PR DESCRIPTION
Using `Object.getOwnPropertyDescriptor(KeyboardEvent.prototype,'key');` on a browser which implements `KeyboardEvent.prototype.key` shows that property is enumerable and configurable. The polyfill don't set those two descriptors breaking code that rely on those.
