### PR TITLE
Also handle lower case ASCII chars

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,6 +87,10 @@
     letter = String.fromCharCode(i);
     keyboardeventKeyPolyfill.keys[i] = [letter.toLowerCase(), letter.toUpperCase()];
   }
+  for (i = 97; i < 123; i++) {
+    letter = String.fromCharCode(i);
+    keyboardeventKeyPolyfill.keys[i] = [letter.toLowerCase(), letter.toUpperCase()];
+  }
 
   function polyfill () {
     if (!('KeyboardEvent' in window) ||


### PR DESCRIPTION
On my chrome when I press the "a" key, I get this.which = 97, so
we also should duplicate the a-z ASCII range in the array.
