### PR TITLE
Update demo to show whitespace

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
       body { font: 2em monospace; }
       .main { margin: 2em 10%; }
       p { color: #333; }
+      code { background: whitesmoke; white-space: pre; padding: 0.1em 0.5em; }
       .projectName { background: yellow; color: #666; display: inline; font-size: 1.5em; font-weight: 300; padding: .2em .4em; }
       .projectName b { color: #000; font-weight: 600; }
       .directions { color: #999; font-style: italic; margin-top: 1.5em; }
@@ -25,7 +26,7 @@
 
       // Don't try `keypress`.
       document.body.addEventListener('keydown', function (e) {
-        var msg = (e.which || e.keyCode) + ' → ' + e.key;
+        var msg = (e.which || e.keyCode) + ' → ' + '<code>' + e.key + '</code>';
         console.log(msg);
         main.innerHTML += '<p>' + msg + '</p>';
         footer.scrollIntoView();


### PR DESCRIPTION
Add some formatting to the demo page to show whitespace in the `key` value print out.  This allows the space key value to be visible:

![image](https://cloud.githubusercontent.com/assets/5067638/14367613/d15ab562-fccd-11e5-9726-efe10d15364a.png)
