### PR TITLE
Run polyfill on IE/Edge because they have non-standard values

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,8 +89,9 @@
   }
 
   function polyfill () {
+    var isEdgeOrIE = (navigator.userAgent.indexOf("MSIE ") > 0 || !!navigator.userAgent.match(/Trident.*rv\:11\./) || navigator.userAgent.indexOf("Edge/") > 0);
     if (!('KeyboardEvent' in window) ||
-        'key' in KeyboardEvent.prototype) {
+        ('key' in KeyboardEvent.prototype && !isEdgeOrIE)) {
       return false;
     }
 


### PR DESCRIPTION
IE/Edge browsers have some non-standard 'key' values,
such as 'ArrowDown', 'ArrowUp' ... events become 'Down', 'Up' ...
So I think it's reasonable to polyfill this property on IE/Edge.

Tested on IE9/10/11, Edge 14

