### PR TITLE
Add CDN usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ Just drop the script on your page and call the `polyfill` method.
 <script>keyboardeventKeyPolyfill.polyfill();</script>
 ```
 
+You can also include it via CDN:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/keyboardevent-key-polyfill@latest/index.min.js"></script>
+```
+
 If you're using AMD:
 
 ```js


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/package/npm/keyboardevent-key-polyfill) to your readme to make it easier to use. jsDelivr is the fastest opensource CDN available and built specifically for production usage.